### PR TITLE
Shift + Click in Inventory + Bug fixes

### DIFF
--- a/SharpCraft/entity/EntityPlayerSP.cs
+++ b/SharpCraft/entity/EntityPlayerSP.cs
@@ -97,45 +97,31 @@ namespace SharpCraft.entity
         public void FastMoveStack(int index)
         {
             ItemStack stack = GetItemStackInInventory(index);
-            int maxStackSize = stack.Item.MaxStackSize();
 
             // return if there is no item to move
             if (stack == null || stack.Item == null)
                 return;
 
+            int maxStackSize = stack.Item.MaxStackSize();
 
             // Hotbar to Inventory
             if (index < Hotbar.Length)
             {
-                // TODO: Add to Itemstack as a function(Find in stack?)
                 // 1. find same object in inventory to stack
                 for (int inventoryIdx = 0; inventoryIdx < Inventory.Length; inventoryIdx++)
                 {
-                    // empty so continue
-                    if (Inventory[inventoryIdx] == null || Inventory[inventoryIdx].Item == null)
-                        continue;
+                    // Continue if:
+                     if (Inventory[inventoryIdx] == null || Inventory[inventoryIdx].Item == null  // different item 
+                     || Inventory[inventoryIdx].IsEmpty  // empty
+                         || Inventory[inventoryIdx].Count >= maxStackSize) // full   
+                     {
+                         continue;
+                     }
 
-                    // check if same item
-                    if (Inventory[inventoryIdx].Item != Hotbar[index].Item)
-                        continue;
-
-                    // check if enough space
-                    if (Inventory[inventoryIdx].Count >= maxStackSize)
-                        continue;
-
-                    // if there is enough for whole inventory stack then combine
-                    if (Inventory[inventoryIdx].Count + Hotbar[index].Count <= maxStackSize)
-                    {
-                        Inventory[inventoryIdx].Count += Hotbar[index].Count;
-                        SetItemStackInHotbar(index, null);
-                        return;
-                    }
-                    else
-                    {
-                        Inventory[inventoryIdx].Count -= maxStackSize - Hotbar[index].Count;
-                        Hotbar[index].Count = maxStackSize;
-
-                    }
+                    // Combine stacks, storing any remainder
+                    ItemStack remainingStack = Inventory[inventoryIdx].Combine(Hotbar[index]);
+                    // Assign remainder as new value
+                    SetItemStackInHotbar(index, remainingStack);
                 }
 
                 // 2. find first free inventory spot
@@ -143,6 +129,10 @@ namespace SharpCraft.entity
                 {
                     // not empty
                     if (Inventory[inventoryIdx] != null && Inventory[inventoryIdx].Item != null)
+                        continue;
+
+                   
+                    if (Hotbar[index] == null)
                         continue;
 
                     // empty slot found
@@ -204,6 +194,9 @@ namespace SharpCraft.entity
                 {
                     // not empty
                     if (Hotbar[hotBarIdx] != null && Hotbar[hotBarIdx].Item != null)
+                        continue;
+
+                    if (Inventory[inventoryItemIdx] == null)
                         continue;
 
                     // empty slot found

--- a/SharpCraft/entity/EntityPlayerSP.cs
+++ b/SharpCraft/entity/EntityPlayerSP.cs
@@ -110,10 +110,12 @@ namespace SharpCraft.entity
                 // 1. find same object in inventory to stack
                 for (int inventoryIdx = 0; inventoryIdx < Inventory.Length; inventoryIdx++)
                 {
-                    // Continue if:
-                     if (Inventory[inventoryIdx] == null || Inventory[inventoryIdx].Item == null  // different item 
-                     || Inventory[inventoryIdx].IsEmpty  // empty
-                         || Inventory[inventoryIdx].Count >= maxStackSize) // full   
+                     if (Inventory[inventoryIdx] == null || Inventory[inventoryIdx].Item == null 
+                        || Hotbar[index] == null || Hotbar[index].Item == null
+                        // Continue if:
+                        || Inventory[inventoryIdx].Item != Hotbar[index].Item // different item
+                        || Inventory[inventoryIdx].IsEmpty  // empty
+                        || Inventory[inventoryIdx].Count >= maxStackSize) // full   
                      {
                          continue;
                      }
@@ -162,31 +164,20 @@ namespace SharpCraft.entity
                 // 1. find same object in hotbar to stack
                 for (int hotBarIdx = 0; hotBarIdx < Hotbar.Length; hotBarIdx++)
                 {
-                    // empty so continue
-                    if (Hotbar[hotBarIdx] == null || Hotbar[hotBarIdx].Item == null)
-                        continue;
-
-                    // check if same item
-                    if (Hotbar[hotBarIdx].Item != Inventory[inventoryItemIdx].Item)
-                        continue;
-
-                    // check if enough space
-                    if (Hotbar[hotBarIdx].Count >= maxStackSize)
-                        continue;
-
-                    // if there is enough for whole inventory stack then combine
-                    if (Hotbar[hotBarIdx].Count + Inventory[inventoryItemIdx].Count <= maxStackSize)
+                    if (Hotbar[hotBarIdx] == null || Hotbar[hotBarIdx].Item == null
+                        || Inventory[inventoryItemIdx] == null || Inventory[inventoryItemIdx].Item == null 
+                        // Continue if:
+                        || Hotbar[hotBarIdx].Item != Inventory[inventoryItemIdx].Item // different item
+                        || Hotbar[hotBarIdx].IsEmpty  // empty
+                        || Hotbar[hotBarIdx].Count >= maxStackSize) // full   
                     {
-                        Hotbar[hotBarIdx].Count += Inventory[inventoryItemIdx].Count;
-                        SetItemStackInInventory(index, null);
-                        return;
+                        continue;
                     }
-                    else
-                    {
-                        Inventory[inventoryItemIdx].Count -= maxStackSize - Hotbar[hotBarIdx].Count;
-                        Hotbar[hotBarIdx].Count = maxStackSize;
-
-                    }
+                    
+                    // Combine stacks, storing any remainder
+                    ItemStack remainingStack = Hotbar[hotBarIdx].Combine(Inventory[inventoryItemIdx]);
+                    // Assign remainder as new value
+                    SetItemStackInInventory(index, remainingStack);
                 }
 
                 // 2. find first free hotbar spot
@@ -268,7 +259,7 @@ namespace SharpCraft.entity
             for(int i = 0; i < Hotbar.Length; i++)
             {
                 ItemStack stack = GetItemStackInInventory(i);
-                if (stack == null || stack.IsEmpty)
+                if (stack == null || stack.IsEmpty || stack.Item != dropped.Item)
                     continue;
 
                 if (dropped.Item == stack.Item && stack.Count <= stack.Item.MaxStackSize())
@@ -295,9 +286,8 @@ namespace SharpCraft.entity
                 }
 
                 // Continue as already looked at Hotbar 
-                if (i > Hotbar.Length)
+                if (i < Hotbar.Length)
                     continue;
-
                 
                 if (dropped.Item == stack.Item && stack.Count <= stack.Item.MaxStackSize())
                 {

--- a/SharpCraft/entity/EntityPlayerSP.cs
+++ b/SharpCraft/entity/EntityPlayerSP.cs
@@ -128,32 +128,22 @@ namespace SharpCraft.entity
 
                 // 2. find first free inventory spot
                 for (int inventoryIdx = 0; inventoryIdx < Inventory.Length; inventoryIdx++)
-                {
-                    // not empty
-                    if (Inventory[inventoryIdx] != null && Inventory[inventoryIdx].Item != null)
-                        continue;
-
-                   
-                    if (Hotbar[index] == null)
-                        continue;
-
-                    // empty slot found
-                    if (Hotbar[index].Count > maxStackSize)
+                {                 
+                    if (Inventory[inventoryIdx] != null && Inventory[inventoryIdx].Item != null
+                        || Hotbar[index] == null)
                     {
-                        ItemStack newStack = Hotbar[index].Copy();      
-                        newStack.Count = maxStackSize;
-                        SetItemStackInInventory(inventoryIdx + Hotbar.Length, newStack);
-
-                        Hotbar[index].Count -= maxStackSize;
                         continue;
-                    }
-                    else
-                    {
-                        SetItemStackInInventory(inventoryIdx + Hotbar.Length, Hotbar[index].Copy());
-                        SetItemStackInHotbar(index, null);
-                        return;
-                    }
-                 
+                    }                 
+
+                    // Initialise inventory slot without an item
+                    if (Inventory[inventoryIdx] == null)
+                        Inventory[inventoryIdx] = new ItemStack(null);
+
+                    // Combine stacks, storing any remainder
+                    ItemStack remainingStack = Inventory[inventoryIdx].Combine(Hotbar[index]);
+                    // Assign remainder as new value
+                    SetItemStackInHotbar(index, remainingStack);
+
                 }
             }
             // Inventory to Hotbar
@@ -176,37 +166,27 @@ namespace SharpCraft.entity
                     
                     // Combine stacks, storing any remainder
                     ItemStack remainingStack = Hotbar[hotBarIdx].Combine(Inventory[inventoryItemIdx]);
-                    // Assign remainder as new value
+                    // Leave remainder
                     SetItemStackInInventory(index, remainingStack);
                 }
 
                 // 2. find first free hotbar spot
                 for (int hotBarIdx = 0; hotBarIdx < Hotbar.Length; hotBarIdx++)
                 {
-                    // not empty
-                    if (Hotbar[hotBarIdx] != null && Hotbar[hotBarIdx].Item != null)
-                        continue;
-
-                    if (Inventory[inventoryItemIdx] == null)
-                        continue;
-
-                    // empty slot found
-                    if (Inventory[inventoryItemIdx].Count > maxStackSize)
+                    if (Hotbar[hotBarIdx] != null && Hotbar[hotBarIdx].Item != null // not empty
+                        || Inventory[inventoryItemIdx] == null)
                     {
-                        ItemStack newStack = Inventory[inventoryItemIdx].Copy();
-                        newStack.Count = maxStackSize;
-                        SetItemStackInHotbar(hotBarIdx, newStack);
-
-                        Inventory[inventoryItemIdx].Count -= maxStackSize;
                         continue;
                     }
-                    else
-                    {
-                        SetItemStackInHotbar(hotBarIdx, Inventory[inventoryItemIdx]);
-                        SetItemStackInInventory(index, null);
-                        return;
-                    }
-                  
+
+                    // Initialise hotbar slot without an item
+                    if (Hotbar[hotBarIdx] == null)
+                        Hotbar[hotBarIdx] = new ItemStack(null);
+
+                    // Combine stacks, storing any remainder
+                    ItemStack remainingStack = Hotbar[hotBarIdx].Combine(Inventory[inventoryItemIdx]);
+                    // Leave remainder
+                    SetItemStackInInventory(index, remainingStack);
                 }
             }
         }
@@ -217,7 +197,6 @@ namespace SharpCraft.entity
                 SetItemStackInHotbar(index, stack);
             else
                 Inventory[index - Hotbar.Length] = stack;
-            //  BEFORE: Inventory[index % Inventory.Length] = stack;
         }
 
         private void SetItemStackInHotbar(int index, ItemStack stack)

--- a/SharpCraft/entity/EntityPlayerSP.cs
+++ b/SharpCraft/entity/EntityPlayerSP.cs
@@ -94,7 +94,6 @@ namespace SharpCraft.entity
             }
         }
 
-        
 
         public void FastMoveStack(int index)
         {
@@ -141,6 +140,10 @@ namespace SharpCraft.entity
                 ItemStack remainingStack = to[inventoryIdx].Combine(from[localSlotIndex]);
                 // Assign remainder as new value
                 setItemFunction(slotIndex, remainingStack);
+
+                // finished
+                if (remainingStack == null || remainingStack.Count <= 0)
+                    return;
             }
 
             // 2. find first free inventory spot
@@ -160,9 +163,9 @@ namespace SharpCraft.entity
                 ItemStack remainingStack = to[inventoryIdx].Combine(from[localSlotIndex]);
                 // Assign remainder as new value
                 setItemFunction(slotIndex, remainingStack);
-
             }
         }
+
 
         public void SetItemStackInInventory(int index, ItemStack stack)
         {

--- a/SharpCraft/item/ItemStack.cs
+++ b/SharpCraft/item/ItemStack.cs
@@ -80,10 +80,11 @@ namespace SharpCraft.item
             // otherwise, combine as much as possible
             else
             {
-                this.Count -= this.Item.MaxStackSize() - other.Count;
+                int difference = this.Item.MaxStackSize() - this.Count;
+                this.Count += difference;
 
                 remainingStack = other.Copy();
-                remainingStack.Count = this.Item.MaxStackSize();
+                remainingStack.Count -= difference;
             }           
 
             return remainingStack;

--- a/SharpCraft/item/ItemStack.cs
+++ b/SharpCraft/item/ItemStack.cs
@@ -57,5 +57,27 @@ namespace SharpCraft.item
         }
 
         public override string ToString() => Item != null ? Item.ToString() : "";
+
+        public ItemStack Combine(ItemStack other)
+        {
+            ItemStack remainingStack;
+
+            // Combine stacks if enough space
+            if (this.Count + other.Count <= this.Item.MaxStackSize())
+            {
+                this.Count += other.Count;
+                remainingStack = null;
+            }
+            // Combine as much as possible
+            else
+            {
+                this.Count -= this.Item.MaxStackSize() - other.Count;
+
+                remainingStack = other.Copy();
+                remainingStack.Count = this.Item.MaxStackSize();
+            }
+
+            return remainingStack;
+        }
     }
 }

--- a/SharpCraft/item/ItemStack.cs
+++ b/SharpCraft/item/ItemStack.cs
@@ -60,7 +60,16 @@ namespace SharpCraft.item
 
         public ItemStack Combine(ItemStack other)
         {
-            ItemStack remainingStack;
+            ItemStack remainingStack = null;
+
+            // Copy item if an item isn't present here
+            if(this.Item == null)
+            {
+                if(other.Item == null)
+                    return remainingStack; // error
+                else
+                    this.Item = other.Item;
+            }
 
             // Combine stacks if enough space
             if (this.Count + other.Count <= this.Item.MaxStackSize())
@@ -68,16 +77,17 @@ namespace SharpCraft.item
                 this.Count += other.Count;
                 remainingStack = null;
             }
-            // Combine as much as possible
+            // otherwise, combine as much as possible
             else
             {
                 this.Count -= this.Item.MaxStackSize() - other.Count;
 
                 remainingStack = other.Copy();
                 remainingStack.Count = this.Item.MaxStackSize();
-            }
+            }           
 
             return remainingStack;
         }
+
     }
 }


### PR DESCRIPTION
Shift+Click Inventory feature:

- When you Shift+Click on a stack of items in the inventory it is moved to the Hot-bar. This is vice-versa if you do the same action but in the Hot-bar. 
- If the same item exists in the destination then the stacks are combined. If there is not enough space then the rest of the stack is overflowed to either a) other stacks of the same item or b) an empty space.

Bug fixes:
1. Inventory storage is now aligned with game representation.
2. When picking up an item that exists both in the Inventory and Hot-bar, the Hot-bar is prioitised for stacking. 