### PR TITLE
Optimisation: Draw stretched background to screen

### DIFF
--- a/SharpCraft/gui/Gui.cs
+++ b/SharpCraft/gui/Gui.cs
@@ -82,6 +82,30 @@ namespace SharpCraft.gui
             Shader.Unbind();
         }
 
+        protected virtual void RenderTextureStretchToScreen(GuiTexture tex)
+        {
+            if (tex == null)
+                return;
+
+            Shader.Bind();
+
+            GL.BindVertexArray(GuiRenderer.GuiQuad.vaoID);
+
+            Shader.UpdateGlobalUniforms();
+            Shader.UpdateModelUniforms();
+            Shader.UpdateInstanceUniforms(Matrix4.Identity, tex);
+
+            GL.EnableVertexAttribArray(0);
+
+            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.BindTexture(TextureTarget.Texture2D, tex.ID);
+            GL.DrawArrays(PrimitiveType.Quads, 0, 4);
+
+            GL.DisableVertexAttribArray(0);
+
+            Shader.Unbind();
+        }
+
         protected virtual void RenderBlock(EnumBlock block, float x, float y, float scale)
         {
             TextureBlockUV UVs = TextureManager.GetUVsFromBlock(block);

--- a/SharpCraft/gui/GuiScreen.cs
+++ b/SharpCraft/gui/GuiScreen.cs
@@ -25,9 +25,9 @@ namespace SharpCraft.gui
         {
             for (int i = 0; i < buttons.Count; i++)
             {
-                GuiButton btn = buttons[i];
+                //GuiButton btn = buttons[i];
 
-                btn.Render(mouseX, mouseY);
+                buttons[i].Render(mouseX, mouseY);
                 //hovered? HoverColor : Vector3.One
                 //if (btn is GuiItemSlot slot && !slot.stack?.IsEmpty == true && slot.stack.Count > 1)
                 //RenderText(slot.stack.Count.ToString(), slot.PosX + 32 * slot.Scale / 2f, slot.PosY + 32 * slot.Scale / 2f + 14, 1, true);
@@ -52,6 +52,7 @@ namespace SharpCraft.gui
             }
         }
 
+        // Draws background to screen, stretching it to the screen size
         protected virtual void DrawBackroundStretch()
         {
             RenderTextureStretchToScreen(background);

--- a/SharpCraft/gui/GuiScreen.cs
+++ b/SharpCraft/gui/GuiScreen.cs
@@ -52,6 +52,11 @@ namespace SharpCraft.gui
             }
         }
 
+        protected virtual void DrawBackroundStretch()
+        {
+            RenderTextureStretchToScreen(background);
+        }
+
         protected virtual void DrawDefaultBackground()
         {
             float sizeX = background_default.TextureSize.Width * background_default.Scale;

--- a/SharpCraft/gui/GuiScreenIngameMenu.cs
+++ b/SharpCraft/gui/GuiScreenIngameMenu.cs
@@ -6,7 +6,7 @@ namespace SharpCraft.gui
     {
         public override void Render(int mouseX, int mouseY)
         {
-            DrawBackground();
+            DrawBackroundStretch();
 
             Size size = SharpCraft.Instance.ClientSize;
 

--- a/SharpCraft/gui/GuiScreenInventory.cs
+++ b/SharpCraft/gui/GuiScreenInventory.cs
@@ -40,7 +40,8 @@ namespace SharpCraft.gui
 
         public override void Render(int mouseX, int mouseY)
         {
-            DrawBackground();
+            //DrawBackground();
+            DrawBackroundStretch();
 
             guiScale = Math.Clamp((SharpCraft.Instance.ClientSize.Width / 640f + SharpCraft.Instance.ClientSize.Width / 480f) / 2, 1.75f, 2);
 

--- a/SharpCraft/gui/GuiScreenInventory.cs
+++ b/SharpCraft/gui/GuiScreenInventory.cs
@@ -40,7 +40,6 @@ namespace SharpCraft.gui
 
         public override void Render(int mouseX, int mouseY)
         {
-            //DrawBackground();
             DrawBackroundStretch();
 
             guiScale = Math.Clamp((SharpCraft.Instance.ClientSize.Width / 640f + SharpCraft.Instance.ClientSize.Width / 480f) / 2, 1.75f, 2);
@@ -62,8 +61,8 @@ namespace SharpCraft.gui
 
             RenderTexture(inventoryBackground, startPosX - 10 * guiScale / 2, startPosY - 10 * guiScale / 2);
 
+            // Hotbar item slots
             float hotbarY = scaledHeight + startPosY + 2 * (scaledHeight + space * 5);
-
             for (int i = 0; i < 9; i++)
             {
                 float x = startPosX + i * (scaledWidth + space);
@@ -85,7 +84,8 @@ namespace SharpCraft.gui
                     targetBtn.Scale = guiScale;
                 }
             }
-
+           
+            // Inventory item slots
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 9; j++)
@@ -106,9 +106,11 @@ namespace SharpCraft.gui
                     }
                 }
             }
-
+                       
+            // Draw slots
             base.Render(mouseX, mouseY);
-
+    
+            // Draw held item
             if (draggedStack != null && !draggedStack.IsEmpty && draggedStack.Item?.InnerItem is EnumBlock block)
             {
                 float x = mouseX - 16 * guiScale / 2;


### PR DESCRIPTION
Stretching the background texture removes the need for the current loops and calculations. Simply, an identity matrix is used on a full-screen quad.  _(best with simple textures such as the transparent black texture)_

Currently used:
- Inventory background
- Pause menu background